### PR TITLE
Update faq.md

### DIFF
--- a/source/content/faq.md
+++ b/source/content/faq.md
@@ -16,7 +16,7 @@ It boils down how to how you want your application to access secrets. The Akv2k8
 The secrets will not be revealed by env-injector and cannot be found in logs, volumes or in Kubernetes. The only place where the secrets exists is in the application process running inside the container. Depending on your security settings for your Pod and Container, you can exec into a shell in your pod and run: 
 
 ```
-cat /proc/1/environ | xargs -0 -L1 |sort
+cat /proc/1/environ | xargs -0 -n1 |sort
 ```
 
 ...replacing `[pid]` with your process ID - often this is 1 in a container. This will list all env variables for the process.


### PR DESCRIPTION
Hi,

Issue : Below command not working 
`
cat /proc/1/environ | xargs -0 -L1 |sort
`
Working command. Review and update in the FAQ doc
`
cat /proc/1/environ | xargs -0 -n1 | sort
`
```
$ cat /proc/1/environ | xargs -0 -L1
xargs: unrecognized option: L
BusyBox v1.28.4 (2018-12-31 18:05:13 UTC) multi-call binary.

Usage: xargs [OPTIONS] [PROG ARGS]

Run PROG on every item given by stdin

        -p      Ask user whether to run each command
        -r      Don't run command if input is empty
        -0      Input is separated by NUL characters
        -a FILE Read from FILE instead of stdin
        -t      Print the command on stderr before execution
        -e[STR] STR stops input processing
        -n N    Pass no more than N args to PROG
        -s N    Pass command line of no more than N bytes
        -I STR  Replace STR within PROG ARGS with input line
        -P N    Run up to N PROGs in parallel
        -x      Exit if size is exceeded
```