### PR TITLE
Added instructions when KeyVault is using RBAC

### DIFF
--- a/source/content/quick-start.mdx
+++ b/source/content/quick-start.mdx
@@ -30,6 +30,8 @@ az keyvault set-policy \
   --spn <service principal id> \ 
   --subscription <azure subscription>
 ```
+  
+Alternatively, if using role-based access control (RBAC), give the K8 cluster's _agentpool_ User-assigned Managed Identity the _Key Value Secret User_ role.
 
 For more details and options, check out [authentication](security/authentication) and [authorization](security/authorization).
 


### PR DESCRIPTION
Quick sentence for how enable akv2k8s to retrieve secrets when the key vault is using RBAC

I don't know how to do this via the CLI