### PR TITLE
Update 5-multi-akvs-to-one-secret.md

### DIFF
--- a/source/content/tutorials/sync/5-multi-akvs-to-one-secret.md
+++ b/source/content/tutorials/sync/5-multi-akvs-to-one-secret.md
@@ -56,17 +56,17 @@ List AzureKeyVaultSecret's:
 
 ```bash
 $ kubectl -n akv-test get akvs
-NAME            VAULT          VAULT OBJECT   SECRET NAME         SYNCHED
-secret-sync-1   akv2k8s-test   my-secret      my-secrets-from-akv  
-secret-sync-2   akv2k8s-test   my-secret      my-secrets-from-akv  
+NAME            VAULT          VAULT OBJECT     SECRET NAME         SYNCHED
+secret-sync-1   akv2k8s-test   my-secret        my-secrets-from-akv  
+secret-sync-2   akv2k8s-test   my-other-secret  my-secrets-from-akv  
 ```
 
-Shortly a Kubernetes secret should exist:
-
+Shortly a Kubernetes secret should exist with two in data filed:
+*(Now we have two secrets data stored in this single secret we created)*
 ```bash
 $ kubectl -n akv-test get secret
 NAME                 TYPE    DATA  AGE
-my-secrets-from-akv  Opaque  1     1m 
+my-secrets-from-akv  Opaque  2     1m 
 ```
 
 Inspect secret to see it contains both akvs values:


### PR DESCRIPTION
The doc section of page "[Sync Multiple AKVS to One Secret](https://akv2k8s.io/tutorials/sync/5-multi-akvs-to-one-secret/)" have few incorrect output of kubernets command, which make this feature look buggy _(if not then this is a bug)_ 
 
1. List AzureKeyVaultSecret's section of doc have incorrent Vault Object reference its should be "my-other-secret " for akvs "secret-sync-2 " and not my-secret which is for "secret-sync-1"
2. Also Shortly a Kubernetes secret should exist, need to show DATA filed with 2 NOT 1, as we are creating 2 secrets data in this single kub secret.

Please review and correct it. 